### PR TITLE
fix: sync overlap prevention + inbox notification & agent tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,13 @@ Because the push explicitly excludes `_inbox/**` and `_outbox/**`, there is no r
 
 By default, mailbox mode is silent — files land in `_inbox` without waking the agent. This keeps costs at zero.
 
-If you want the agent to react when files arrive, set `"notifyOnInbox": true`. After each drain that moves files, the plugin injects a system event like:
+If you want the agent to react when files arrive, set `"notifyOnInbox": true`. After each drain that moves files, the plugin sends a rich notification to the agent including:
 
-> `[workspace-sync] New files in _inbox: report.pdf, data.csv`
+- A bullet-point list of new files (up to 10, with overflow count)
+- Available workspace directories so the agent can suggest where to put them
+- A prompt asking where to move the files
 
-This wakes the agent on its next heartbeat. The agent sees the message and can process the files — for example, reading, summarizing, or filing them.
+The agent picks this up on whichever channel it's running (Telegram, Discord, etc.) and can ask the user where to file the incoming items.
 
 **This costs credits.** Each notification triggers an agent turn. Only enable it if you want the agent to actively respond to incoming files.
 
@@ -155,6 +157,29 @@ This wakes the agent on its next heartbeat. The agent sees the message and can p
   "notifyOnInbox": true
 }
 ```
+
+##### `workspace_inbox` agent tool
+
+When `mode` is `"mailbox"`, the plugin automatically registers a **`workspace_inbox`** tool that the LLM agent can call. This lets the agent interactively manage inbox files on behalf of the user — no shell commands needed.
+
+| Action | What it does |
+|--------|-------------|
+| `list` | Show all files in `_inbox` (with sizes) and workspace directories (up to 3 levels deep) |
+| `peek` | Inspect a specific inbox file or directory — returns metadata (name, size, modified date) |
+| `move` | Move files from `_inbox` to a target workspace directory. Creates the directory if it doesn't exist. Supports moving specific files or all at once. |
+
+**End-to-end flow:**
+
+1. Someone drops a file in the Dropbox `_outbox` folder (or any cloud provider's outbox)
+2. Next mailbox drain pulls it into the workspace `_inbox`
+3. If `notifyOnInbox` is enabled, the agent wakes up and tells you on Telegram: *"New files arrived in _inbox: report.pdf. Workspace directories: CODE, docs. Where should I put them?"*
+4. You reply: *"move them to CODE/myproject"*
+5. The agent calls `workspace_inbox` with `action: "move", target: "CODE/myproject"`
+6. Files are moved, agent confirms
+
+The tool enforces path safety — it rejects absolute paths and traversal attempts (`../`). Target directories are always resolved relative to the workspace root.
+
+> **Note:** The `workspace_inbox` tool is always available in mailbox mode, even without `notifyOnInbox`. You can ask the agent to check the inbox or move files manually at any time.
 
 #### `mirror` mode
 

--- a/README.src.md
+++ b/README.src.md
@@ -154,11 +154,13 @@ Because the push explicitly excludes `_inbox/**` and `_outbox/**`, there is no r
 
 By default, mailbox mode is silent — files land in `_inbox` without waking the agent. This keeps costs at zero.
 
-If you want the agent to react when files arrive, set `"notifyOnInbox": true`. After each drain that moves files, the plugin injects a system event like:
+If you want the agent to react when files arrive, set `"notifyOnInbox": true`. After each drain that moves files, the plugin sends a rich notification to the agent including:
 
-> `[workspace-sync] New files in _inbox: report.pdf, data.csv`
+- A bullet-point list of new files (up to 10, with overflow count)
+- Available workspace directories so the agent can suggest where to put them
+- A prompt asking where to move the files
 
-This wakes the agent on its next heartbeat. The agent sees the message and can process the files — for example, reading, summarizing, or filing them.
+The agent picks this up on whichever channel it's running (Telegram, Discord, etc.) and can ask the user where to file the incoming items.
 
 **This costs credits.** Each notification triggers an agent turn. Only enable it if you want the agent to actively respond to incoming files.
 
@@ -171,6 +173,29 @@ This wakes the agent on its next heartbeat. The agent sees the message and can p
   "notifyOnInbox": true
 }
 ```
+
+##### `workspace_inbox` agent tool
+
+When `mode` is `"mailbox"`, the plugin automatically registers a **`workspace_inbox`** tool that the LLM agent can call. This lets the agent interactively manage inbox files on behalf of the user — no shell commands needed.
+
+| Action | What it does |
+|--------|-------------|
+| `list` | Show all files in `_inbox` (with sizes) and workspace directories (up to 3 levels deep) |
+| `peek` | Inspect a specific inbox file or directory — returns metadata (name, size, modified date) |
+| `move` | Move files from `_inbox` to a target workspace directory. Creates the directory if it doesn't exist. Supports moving specific files or all at once. |
+
+**End-to-end flow:**
+
+1. Someone drops a file in the Dropbox `_outbox` folder (or any cloud provider's outbox)
+2. Next mailbox drain pulls it into the workspace `_inbox`
+3. If `notifyOnInbox` is enabled, the agent wakes up and tells you on Telegram: *"New files arrived in _inbox: report.pdf. Workspace directories: CODE, docs. Where should I put them?"*
+4. You reply: *"move them to CODE/myproject"*
+5. The agent calls `workspace_inbox` with `action: "move", target: "CODE/myproject"`
+6. Files are moved, agent confirms
+
+The tool enforces path safety — it rejects absolute paths and traversal attempts (`../`). Target directories are always resolved relative to the workspace root.
+
+> **Note:** The `workspace_inbox` tool is always available in mailbox mode, even without `notifyOnInbox`. You can ask the agent to check the inbox or move files manually at any time.
 
 #### `mirror` mode
 

--- a/src/inbox-tool.ts
+++ b/src/inbox-tool.ts
@@ -1,5 +1,5 @@
-import { join, resolve, relative, isAbsolute } from "node:path";
-import { existsSync, readdirSync, renameSync, mkdirSync, statSync, cpSync, rmSync } from "node:fs";
+import { join, resolve, relative, isAbsolute, sep } from "node:path";
+import { existsSync, readdirSync, renameSync, mkdirSync, lstatSync, cpSync, rmSync } from "node:fs";
 
 export const INBOX_TOOL_NAME = "workspace_inbox";
 
@@ -40,6 +40,20 @@ function jsonResult(payload: unknown) {
   };
 }
 
+/** Reject names containing path separators or traversal segments. */
+function isSafeBasename(name: string): boolean {
+  if (!name || name === "." || name === "..") return false;
+  if (name.includes("/") || name.includes("\\")) return false;
+  if (name.includes("\0")) return false;
+  return true;
+}
+
+/** Verify resolved path is strictly inside container dir. */
+function isInsideDir(container: string, candidate: string): boolean {
+  const rel = relative(container, candidate);
+  return !rel.startsWith("..") && !isAbsolute(rel);
+}
+
 function listDirsRecursive(base: string, prefix: string, depth: number, maxDepth: number): string[] {
   if (depth >= maxDepth) return [];
   try {
@@ -58,8 +72,9 @@ function listDirsRecursive(base: string, prefix: string, depth: number, maxDepth
   }
 }
 
-export function createInboxTool(workspaceDir: string) {
-  const inboxDir = join(workspaceDir, "_inbox");
+export function createInboxTool(workspaceDir: string, inboxPath?: string) {
+  const inboxDir = inboxPath ?? join(workspaceDir, "_inbox");
+  const inboxReal = resolve(inboxDir);
 
   return {
     name: INBOX_TOOL_NAME,
@@ -77,12 +92,14 @@ export function createInboxTool(workspaceDir: string) {
         const inboxFiles: string[] = [];
         if (existsSync(inboxDir)) {
           for (const entry of readdirSync(inboxDir, { withFileTypes: true })) {
-            const stat = statSync(join(inboxDir, entry.name));
-            inboxFiles.push(
-              entry.isDirectory()
-                ? `📁 ${entry.name}/`
-                : `📄 ${entry.name} (${formatBytes(stat.size)})`,
-            );
+            const stat = lstatSync(join(inboxDir, entry.name));
+            if (stat.isSymbolicLink()) {
+              inboxFiles.push(`🔗 ${entry.name} (symlink)`);
+            } else if (entry.isDirectory()) {
+              inboxFiles.push(`📁 ${entry.name}/`);
+            } else {
+              inboxFiles.push(`📄 ${entry.name} (${formatBytes(stat.size)})`);
+            }
           }
         }
 
@@ -99,11 +116,24 @@ export function createInboxTool(workspaceDir: string) {
         if (!target) {
           return jsonResult({ error: "target (filename) is required for peek" });
         }
-        const filePath = join(inboxDir, target);
+
+        if (!isSafeBasename(target)) {
+          return jsonResult({ error: "target must be a simple filename (no path separators or traversal)" });
+        }
+
+        const filePath = resolve(inboxDir, target);
+        if (!isInsideDir(inboxReal, filePath)) {
+          return jsonResult({ error: "target escapes the inbox directory" });
+        }
+
         if (!existsSync(filePath)) {
           return jsonResult({ error: `File not found in inbox: ${target}` });
         }
-        const stat = statSync(filePath);
+
+        const stat = lstatSync(filePath);
+        if (stat.isSymbolicLink()) {
+          return jsonResult({ type: "symlink", name: target, note: "Symlinks are not followed for safety" });
+        }
         if (stat.isDirectory()) {
           const contents = readdirSync(filePath);
           return jsonResult({
@@ -131,7 +161,7 @@ export function createInboxTool(workspaceDir: string) {
 
         const destDir = resolve(workspaceDir, target);
         const wsReal = resolve(workspaceDir);
-        if (!destDir.startsWith(wsReal)) {
+        if (!isInsideDir(wsReal, destDir)) {
           return jsonResult({ error: "target must be within the workspace" });
         }
 
@@ -150,15 +180,30 @@ export function createInboxTool(workspaceDir: string) {
         const errors: string[] = [];
 
         for (const name of filesToMove) {
-          const src = join(inboxDir, name);
+          if (!isSafeBasename(name)) {
+            errors.push(`${name}: rejected — must be a simple filename (no path separators or traversal)`);
+            continue;
+          }
+
+          const src = resolve(inboxDir, name);
+          if (!isInsideDir(inboxReal, src)) {
+            errors.push(`${name}: rejected — escapes inbox directory`);
+            continue;
+          }
+
           const dest = join(destDir, name);
           try {
             if (!existsSync(src)) {
               errors.push(`${name}: not found in inbox`);
               continue;
             }
-            // Use copy+delete for cross-device moves
-            const srcStat = statSync(src);
+
+            const srcStat = lstatSync(src);
+            if (srcStat.isSymbolicLink()) {
+              errors.push(`${name}: skipped — symlinks are not moved for safety`);
+              continue;
+            }
+
             if (srcStat.isDirectory()) {
               cpSync(src, dest, { recursive: true });
               rmSync(src, { recursive: true, force: true });

--- a/src/inbox-tool.ts
+++ b/src/inbox-tool.ts
@@ -1,0 +1,196 @@
+import { join, resolve, relative, isAbsolute } from "node:path";
+import { existsSync, readdirSync, renameSync, mkdirSync, statSync, cpSync, rmSync } from "node:fs";
+
+export const INBOX_TOOL_NAME = "workspace_inbox";
+
+export const InboxToolSchema = {
+  type: "object",
+  properties: {
+    action: {
+      type: "string",
+      description:
+        "Action to perform: list (show inbox files + workspace dirs), move (move inbox files to a target dir), peek (show contents of a specific inbox file path).",
+      enum: ["list", "move", "peek"],
+    },
+    target: {
+      type: "string",
+      description:
+        'For "move": relative directory path within the workspace to move files into (e.g. "CODE/myproject"). Created if it doesn\'t exist. For "peek": filename in _inbox to inspect.',
+    },
+    files: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        'For "move": specific filenames to move from _inbox. If omitted, moves all inbox files.',
+    },
+  },
+  required: ["action"],
+};
+
+type InboxToolParams = {
+  action: "list" | "move" | "peek";
+  target?: string;
+  files?: string[];
+};
+
+function jsonResult(payload: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+function listDirsRecursive(base: string, prefix: string, depth: number, maxDepth: number): string[] {
+  if (depth >= maxDepth) return [];
+  try {
+    const entries = readdirSync(base, { withFileTypes: true });
+    const dirs: string[] = [];
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      if (e.name.startsWith(".") || e.name === "node_modules" || e.name === "_inbox" || e.name === "_outbox") continue;
+      const rel = prefix ? `${prefix}/${e.name}` : e.name;
+      dirs.push(rel);
+      dirs.push(...listDirsRecursive(join(base, e.name), rel, depth + 1, maxDepth));
+    }
+    return dirs;
+  } catch {
+    return [];
+  }
+}
+
+export function createInboxTool(workspaceDir: string) {
+  const inboxDir = join(workspaceDir, "_inbox");
+
+  return {
+    name: INBOX_TOOL_NAME,
+    label: "Workspace Inbox",
+    description:
+      "Manage files that arrived in the workspace _inbox from cloud sync. " +
+      "Actions: list (show inbox files and workspace directories), " +
+      "move (move inbox files to a workspace directory), " +
+      "peek (inspect an inbox file).",
+    parameters: InboxToolSchema,
+    async execute(_toolCallId: string, params: InboxToolParams) {
+      const { action, target, files } = params;
+
+      if (action === "list") {
+        const inboxFiles: string[] = [];
+        if (existsSync(inboxDir)) {
+          for (const entry of readdirSync(inboxDir, { withFileTypes: true })) {
+            const stat = statSync(join(inboxDir, entry.name));
+            inboxFiles.push(
+              entry.isDirectory()
+                ? `📁 ${entry.name}/`
+                : `📄 ${entry.name} (${formatBytes(stat.size)})`,
+            );
+          }
+        }
+
+        const workspaceDirs = listDirsRecursive(workspaceDir, "", 0, 3);
+
+        return jsonResult({
+          inbox: inboxFiles.length > 0 ? inboxFiles : ["(empty)"],
+          workspaceDirectories: workspaceDirs.length > 0 ? workspaceDirs : ["(none)"],
+          hint: 'Use action "move" with a target directory to move inbox files.',
+        });
+      }
+
+      if (action === "peek") {
+        if (!target) {
+          return jsonResult({ error: "target (filename) is required for peek" });
+        }
+        const filePath = join(inboxDir, target);
+        if (!existsSync(filePath)) {
+          return jsonResult({ error: `File not found in inbox: ${target}` });
+        }
+        const stat = statSync(filePath);
+        if (stat.isDirectory()) {
+          const contents = readdirSync(filePath);
+          return jsonResult({
+            type: "directory",
+            name: target,
+            entries: contents.length > 50 ? [...contents.slice(0, 50), `… +${contents.length - 50} more`] : contents,
+          });
+        }
+        return jsonResult({
+          type: "file",
+          name: target,
+          size: formatBytes(stat.size),
+          modified: stat.mtime.toISOString(),
+        });
+      }
+
+      if (action === "move") {
+        if (!target) {
+          return jsonResult({ error: "target directory is required for move" });
+        }
+
+        if (isAbsolute(target)) {
+          return jsonResult({ error: "target must be a relative path within the workspace" });
+        }
+
+        const destDir = resolve(workspaceDir, target);
+        const wsReal = resolve(workspaceDir);
+        if (!destDir.startsWith(wsReal)) {
+          return jsonResult({ error: "target must be within the workspace" });
+        }
+
+        if (!existsSync(inboxDir)) {
+          return jsonResult({ moved: [], error: "inbox is empty" });
+        }
+
+        const filesToMove = files ?? readdirSync(inboxDir);
+        if (filesToMove.length === 0) {
+          return jsonResult({ moved: [], message: "No files to move" });
+        }
+
+        mkdirSync(destDir, { recursive: true });
+
+        const moved: string[] = [];
+        const errors: string[] = [];
+
+        for (const name of filesToMove) {
+          const src = join(inboxDir, name);
+          const dest = join(destDir, name);
+          try {
+            if (!existsSync(src)) {
+              errors.push(`${name}: not found in inbox`);
+              continue;
+            }
+            // Use copy+delete for cross-device moves
+            const srcStat = statSync(src);
+            if (srcStat.isDirectory()) {
+              cpSync(src, dest, { recursive: true });
+              rmSync(src, { recursive: true, force: true });
+            } else {
+              try {
+                renameSync(src, dest);
+              } catch {
+                cpSync(src, dest);
+                rmSync(src);
+              }
+            }
+            moved.push(`${name} → ${relative(workspaceDir, dest)}`);
+          } catch (err) {
+            errors.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
+
+        return jsonResult({
+          moved,
+          errors: errors.length > 0 ? errors : undefined,
+          remaining: existsSync(inboxDir) ? readdirSync(inboxDir).length : 0,
+        });
+      }
+
+      return jsonResult({ error: `Unknown action: ${action}` });
+    },
+  };
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,12 +30,14 @@ import {
   type RcloneSyncResult,
 } from "./rclone.js";
 import { homedir } from "node:os";
+import { readdirSync } from "node:fs";
 import type { WorkspaceSyncConfig, WorkspaceSyncProvider, RawPluginConfig, NestedPluginConfig } from "./types.js";
 
 function isErr<T extends { ok: boolean }>(r: T): r is Extract<T, { ok: false }> {
   return !r.ok;
 }
 import { startSyncManager, stopSyncManager, getSyncManagerStatus, isSyncing, triggerImmediateSync } from "./sync-manager.js";
+import { createInboxTool } from "./inbox-tool.js";
 import {
   runBackup,
   runRestore,
@@ -710,6 +712,17 @@ const workspaceSyncPlugin = {
     );
 
     // ========================================================================
+    // Agent Tool — inbox file management
+    // ========================================================================
+
+    if (syncConfig.mode === "mailbox") {
+      api.registerTool((ctx) => {
+        const wsDir = ctx.workspaceDir ?? api.resolvePath("workspace");
+        return createInboxTool(wsDir);
+      });
+    }
+
+    // ========================================================================
     // Session Hooks
     // ========================================================================
 
@@ -782,10 +795,24 @@ const workspaceSyncPlugin = {
         let onInboxFiles: ((files: string[]) => void) | undefined;
         if (syncConfig.notifyOnInbox) {
           onInboxFiles = (files) => {
-            const listing = files.length <= 5
-              ? files.join(", ")
-              : `${files.slice(0, 5).join(", ")} and ${files.length - 5} more`;
-            const text = `[workspace-sync] New files in _inbox: ${listing}`;
+            const listing = files.length <= 10
+              ? files.map((f) => `  • ${f}`).join("\n")
+              : files.slice(0, 10).map((f) => `  • ${f}`).join("\n") + `\n  … and ${files.length - 10} more`;
+
+            let dirListing = "";
+            try {
+              const dirs = readdirSync(wsDir, { withFileTypes: true })
+                .filter((d) => d.isDirectory() && !d.name.startsWith(".") && d.name !== "_inbox" && d.name !== "_outbox" && d.name !== "node_modules")
+                .map((d) => d.name)
+                .sort();
+              if (dirs.length > 0) {
+                dirListing = "\n\nWorkspace directories:\n" + dirs.map((d) => `  📁 ${d}`).join("\n");
+              }
+            } catch {
+              // best-effort
+            }
+
+            const text = `📥 New files arrived in _inbox:\n${listing}${dirListing}\n\nTo move them, tell me which directory (e.g. "move inbox files to CODE/myproject").`;
 
             const cfg = api.config as Record<string, any>;
             const agents = cfg?.agents?.list ?? [];
@@ -797,7 +824,7 @@ const workspaceSyncPlugin = {
               ? "global"
               : `agent:${defaultAgentId}:${mainKey}`;
 
-            api.logger.info(`${text} (notifying session ${sessionKey})`);
+            api.logger.info(`[workspace-sync] Inbox notification → session ${sessionKey}: ${files.length} file(s)`);
 
             try {
               api.runtime.system.enqueueSystemEvent(text, { sessionKey });

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ import type { WorkspaceSyncConfig, WorkspaceSyncProvider, RawPluginConfig, Neste
 function isErr<T extends { ok: boolean }>(r: T): r is Extract<T, { ok: false }> {
   return !r.ok;
 }
-import { startSyncManager, stopSyncManager, getSyncManagerStatus } from "./sync-manager.js";
+import { startSyncManager, stopSyncManager, getSyncManagerStatus, isSyncing, triggerImmediateSync } from "./sync-manager.js";
 import {
   runBackup,
   runRestore,
@@ -714,7 +714,7 @@ const workspaceSyncPlugin = {
     // ========================================================================
 
     if (syncConfig.onSessionStart) {
-      api.on("session_start", async (_event, ctx) => {
+      api.on("session_start", async (_event, _ctx) => {
         if (!syncConfig.provider || syncConfig.provider === "off") return;
 
         if (!syncConfig.mode) {
@@ -722,88 +722,25 @@ const workspaceSyncPlugin = {
           return;
         }
 
+        if (isSyncing()) {
+          api.logger.info("[workspace-sync] sync already in progress, skipping session start trigger");
+          return;
+        }
+
         api.logger.info(`[workspace-sync] triggered on session start (mode: ${syncConfig.mode})`);
 
         try {
-          const installed = await isRcloneInstalled();
-          if (!installed) {
-            api.logger.warn("[workspace-sync] rclone not installed, skipping sync");
-            return;
-          }
-
-          const wsDir = ctx.agentId
-            ? api.resolvePath(`agents/${ctx.agentId}/workspace`)
-            : api.resolvePath("workspace");
-
-          const resolved = resolveSyncConfig(syncConfig, wsDir);
-
-          ensureRcloneConfigFromConfig(syncConfig, resolved.configPath, resolved.remoteName);
-
-          if (!isRcloneConfigured(resolved.configPath, resolved.remoteName)) {
-            api.logger.warn(
-              `[workspace-sync] rclone not configured for "${resolved.remoteName}", skipping`,
-            );
-            return;
-          }
-
-          let result: RcloneSyncResult;
-
-          if (resolved.mode === "mailbox") {
-            const mailboxExcludes = [...resolved.exclude, "_inbox/**", "_outbox/**"];
-            result = await runSync({
-              configPath: resolved.configPath,
-              remoteName: resolved.remoteName,
-              remotePath: resolved.remotePath,
-              localPath: resolved.localPath,
-              direction: "push",
-              exclude: mailboxExcludes,
-              timeoutMs: resolved.timeoutMs,
-              verbose: !!api.logger.debug,
-            });
-          } else if (resolved.mode === "mirror") {
-            result = await runSync({
-              configPath: resolved.configPath,
-              remoteName: resolved.remoteName,
-              remotePath: resolved.remotePath,
-              localPath: resolved.localPath,
-              direction: "pull",
-              exclude: resolved.exclude,
-              timeoutMs: resolved.timeoutMs,
-              verbose: !!api.logger.debug,
-            });
-          } else {
-            result = await runBisync({
-              configPath: resolved.configPath,
-              remoteName: resolved.remoteName,
-              remotePath: resolved.remotePath,
-              localPath: resolved.localPath,
-              conflictResolve: resolved.conflictResolve,
-              exclude: resolved.exclude,
-              copySymlinks: resolved.copySymlinks,
-              timeoutMs: resolved.timeoutMs,
-              verbose: !!api.logger.debug,
-            });
-          }
-
-          if (result.ok) {
-            api.logger.info("[workspace-sync] session start sync completed");
-          } else if ((result as any).error?.includes("--resync")) {
-            api.logger.warn(
-              "[workspace-sync] first sync requires manual --resync. Run: openclaw workspace-sync sync --resync",
-            );
-          } else {
-            api.logger.error(`[workspace-sync] sync failed: ${(result as any).error}`);
-          }
+          await triggerImmediateSync();
         } catch (err) {
           api.logger.error(
-            `[workspace-sync] error: ${err instanceof Error ? err.message : String(err)}`,
+            `[workspace-sync] session start sync error: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
       });
     }
 
     if (syncConfig.onSessionEnd) {
-      api.on("session_end", async (_event, ctx) => {
+      api.on("session_end", async (_event, _ctx) => {
         if (!syncConfig.provider || syncConfig.provider === "off") return;
 
         if (!syncConfig.mode) {
@@ -811,69 +748,18 @@ const workspaceSyncPlugin = {
           return;
         }
 
+        if (isSyncing()) {
+          api.logger.info("[workspace-sync] sync already in progress, skipping session end trigger");
+          return;
+        }
+
         api.logger.info(`[workspace-sync] triggered on session end (mode: ${syncConfig.mode})`);
 
         try {
-          const installed = await isRcloneInstalled();
-          if (!installed) return;
-
-          const wsDir = ctx.agentId
-            ? api.resolvePath(`agents/${ctx.agentId}/workspace`)
-            : api.resolvePath("workspace");
-
-          const resolved = resolveSyncConfig(syncConfig, wsDir);
-
-          ensureRcloneConfigFromConfig(syncConfig, resolved.configPath, resolved.remoteName);
-
-          if (!isRcloneConfigured(resolved.configPath, resolved.remoteName)) return;
-
-          let result: RcloneSyncResult;
-
-          if (resolved.mode === "mailbox") {
-            const mailboxExcludes = [...resolved.exclude, "_inbox/**", "_outbox/**"];
-            result = await runSync({
-              configPath: resolved.configPath,
-              remoteName: resolved.remoteName,
-              remotePath: resolved.remotePath,
-              localPath: resolved.localPath,
-              direction: "push",
-              exclude: mailboxExcludes,
-              timeoutMs: resolved.timeoutMs,
-              verbose: !!api.logger.debug,
-            });
-          } else if (resolved.mode === "mirror") {
-            result = await runSync({
-              configPath: resolved.configPath,
-              remoteName: resolved.remoteName,
-              remotePath: resolved.remotePath,
-              localPath: resolved.localPath,
-              direction: "pull",
-              exclude: resolved.exclude,
-              timeoutMs: resolved.timeoutMs,
-              verbose: !!api.logger.debug,
-            });
-          } else {
-            result = await runBisync({
-              configPath: resolved.configPath,
-              remoteName: resolved.remoteName,
-              remotePath: resolved.remotePath,
-              localPath: resolved.localPath,
-              conflictResolve: resolved.conflictResolve,
-              exclude: resolved.exclude,
-              copySymlinks: resolved.copySymlinks,
-              timeoutMs: resolved.timeoutMs,
-              verbose: !!api.logger.debug,
-            });
-          }
-
-          if (result.ok) {
-            api.logger.info("[workspace-sync] session end sync completed");
-          } else {
-            api.logger.error(`[workspace-sync] sync failed: ${(result as any).error}`);
-          }
+          await triggerImmediateSync();
         } catch (err) {
           api.logger.error(
-            `[workspace-sync] error: ${err instanceof Error ? err.message : String(err)}`,
+            `[workspace-sync] session end sync error: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./rclone.js";
 import { homedir } from "node:os";
 import { readdirSync } from "node:fs";
+import { join } from "node:path";
 import type { WorkspaceSyncConfig, WorkspaceSyncProvider, RawPluginConfig, NestedPluginConfig } from "./types.js";
 
 function isErr<T extends { ok: boolean }>(r: T): r is Extract<T, { ok: false }> {
@@ -718,7 +719,9 @@ const workspaceSyncPlugin = {
     if (syncConfig.mode === "mailbox") {
       api.registerTool((ctx) => {
         const wsDir = ctx.workspaceDir ?? api.resolvePath("workspace");
-        return createInboxTool(wsDir);
+        const resolved = resolveSyncConfig(syncConfig, wsDir);
+        const inboxPath = join(resolved.localPath, "_inbox");
+        return createInboxTool(wsDir, inboxPath);
       });
     }
 

--- a/src/sync-manager.ts
+++ b/src/sync-manager.ts
@@ -415,6 +415,10 @@ export function getSyncManagerStatus(): {
   };
 }
 
+export function isSyncing(): boolean {
+  return state.syncing;
+}
+
 export async function triggerImmediateSync(): Promise<void> {
   await doSync();
 }

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,13 +1,12 @@
 /**
  * Tests for session start/end hook registration and behavior.
  *
- * Verifies that the plugin registers hooks correctly and that the hook
- * handlers call rclone with the right parameters based on config.
+ * Session hooks now delegate to triggerImmediateSync() from the sync manager,
+ * checking isSyncing() first to avoid overlapping syncs.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock rclone before importing the plugin
 vi.mock("../src/rclone.js", () => ({
   setLogger: vi.fn(),
   isRcloneInstalled: vi.fn(),
@@ -28,9 +27,11 @@ vi.mock("../src/sync-manager.js", () => ({
   startSyncManager: vi.fn(),
   stopSyncManager: vi.fn(),
   getSyncManagerStatus: vi.fn(() => ({ running: false })),
+  isSyncing: vi.fn(() => false),
+  triggerImmediateSync: vi.fn(),
 }));
 
-import * as rclone from "../src/rclone.js";
+import * as syncManager from "../src/sync-manager.js";
 import workspaceSyncPlugin from "../src/index.js";
 
 type HookHandler = (event: Record<string, unknown>, ctx: Record<string, unknown>) => Promise<void>;
@@ -96,6 +97,7 @@ describe("workspace-sync session hooks", () => {
   it("registers session_start hook when onSessionStart is true", () => {
     const { api, hooks } = createMockApi({
       provider: "dropbox",
+      mode: "mailbox",
       remotePath: "openclaw-share",
       onSessionStart: true,
     });
@@ -109,6 +111,7 @@ describe("workspace-sync session hooks", () => {
   it("registers session_end hook when onSessionEnd is true", () => {
     const { api, hooks } = createMockApi({
       provider: "dropbox",
+      mode: "mailbox",
       remotePath: "openclaw-share",
       onSessionEnd: true,
     });
@@ -122,6 +125,7 @@ describe("workspace-sync session hooks", () => {
   it("registers both hooks when both are enabled", () => {
     const { api, hooks } = createMockApi({
       provider: "dropbox",
+      mode: "mailbox",
       remotePath: "openclaw-share",
       onSessionStart: true,
       onSessionEnd: true,
@@ -137,50 +141,17 @@ describe("workspace-sync session hooks", () => {
     it("skips when provider is off", async () => {
       const { api, hooks } = createMockApi({
         provider: "off",
+        mode: "mailbox",
         onSessionStart: true,
       });
 
       workspaceSyncPlugin.register(api as any);
       await hooks.session_start!({}, { agentId: "main", sessionId: "s1" });
 
-      expect(rclone.isRcloneInstalled).not.toHaveBeenCalled();
+      expect(syncManager.triggerImmediateSync).not.toHaveBeenCalled();
     });
 
-    it("warns when rclone is not installed", async () => {
-      vi.mocked(rclone.isRcloneInstalled).mockResolvedValue(false);
-
-      const { api, hooks } = createMockApi({
-        provider: "dropbox",
-        remotePath: "openclaw-share",
-        onSessionStart: true,
-      });
-
-      workspaceSyncPlugin.register(api as any);
-      await hooks.session_start!({}, { agentId: "main", sessionId: "s1" });
-
-      expect(rclone.isRcloneInstalled).toHaveBeenCalled();
-      expect(api.logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("rclone not installed"),
-      );
-    });
-
-    it("warns when rclone is not configured", async () => {
-      vi.mocked(rclone.isRcloneInstalled).mockResolvedValue(true);
-      vi.mocked(rclone.isRcloneConfigured).mockReturnValue(false);
-      vi.mocked(rclone.resolveSyncConfig).mockReturnValue({
-        provider: "dropbox",
-        remoteName: "cloud",
-        remotePath: "openclaw-share",
-        localPath: "/resolved/agents/main/workspace/shared",
-        configPath: "/home/.config/rclone/rclone.conf",
-        conflictResolve: "newer",
-        exclude: [],
-        copySymlinks: false,
-        interval: 0,
-        onSessionStart: true,
-        onSessionEnd: false,
-      });
-
+    it("skips when mode is not set", async () => {
       const { api, hooks } = createMockApi({
         provider: "dropbox",
         remotePath: "openclaw-share",
@@ -191,30 +162,17 @@ describe("workspace-sync session hooks", () => {
       await hooks.session_start!({}, { agentId: "main", sessionId: "s1" });
 
       expect(api.logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('rclone not configured for "cloud"'),
+        "[workspace-sync] mode not set, skipping session start sync",
       );
+      expect(syncManager.triggerImmediateSync).not.toHaveBeenCalled();
     });
 
-    it("runs bisync on session start", async () => {
-      vi.mocked(rclone.isRcloneInstalled).mockResolvedValue(true);
-      vi.mocked(rclone.isRcloneConfigured).mockReturnValue(true);
-      vi.mocked(rclone.resolveSyncConfig).mockReturnValue({
-        provider: "dropbox",
-        remoteName: "cloud",
-        remotePath: "openclaw-share",
-        localPath: "/workspace/shared",
-        configPath: "/home/.config/rclone/rclone.conf",
-        conflictResolve: "newer",
-        exclude: [".git/**"],
-        copySymlinks: false,
-        interval: 0,
-        onSessionStart: true,
-        onSessionEnd: false,
-      });
-      vi.mocked(rclone.runBisync).mockResolvedValue({ ok: true });
+    it("skips when sync is already in progress", async () => {
+      vi.mocked(syncManager.isSyncing).mockReturnValue(true);
 
       const { api, hooks } = createMockApi({
         provider: "dropbox",
+        mode: "mailbox",
         remotePath: "openclaw-share",
         onSessionStart: true,
       });
@@ -222,42 +180,19 @@ describe("workspace-sync session hooks", () => {
       workspaceSyncPlugin.register(api as any);
       await hooks.session_start!({}, { agentId: "main", sessionId: "s1" });
 
-      expect(rclone.runBisync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          remoteName: "cloud",
-          remotePath: "openclaw-share",
-          localPath: "/workspace/shared",
-          conflictResolve: "newer",
-        }),
-      );
       expect(api.logger.info).toHaveBeenCalledWith(
-        expect.stringContaining("session start sync completed"),
+        "[workspace-sync] sync already in progress, skipping session start trigger",
       );
+      expect(syncManager.triggerImmediateSync).not.toHaveBeenCalled();
     });
 
-    it("warns about --resync on first run error", async () => {
-      vi.mocked(rclone.isRcloneInstalled).mockResolvedValue(true);
-      vi.mocked(rclone.isRcloneConfigured).mockReturnValue(true);
-      vi.mocked(rclone.resolveSyncConfig).mockReturnValue({
-        provider: "dropbox",
-        remoteName: "cloud",
-        remotePath: "openclaw-share",
-        localPath: "/workspace/shared",
-        configPath: "/home/.config/rclone/rclone.conf",
-        conflictResolve: "newer",
-        exclude: [],
-        copySymlinks: false,
-        interval: 0,
-        onSessionStart: true,
-        onSessionEnd: false,
-      });
-      vi.mocked(rclone.runBisync).mockResolvedValue({
-        ok: false,
-        error: "bisync requires --resync on first run",
-      });
+    it("calls triggerImmediateSync on session start", async () => {
+      vi.mocked(syncManager.isSyncing).mockReturnValue(false);
+      vi.mocked(syncManager.triggerImmediateSync).mockResolvedValue();
 
       const { api, hooks } = createMockApi({
         provider: "dropbox",
+        mode: "mailbox",
         remotePath: "openclaw-share",
         onSessionStart: true,
       });
@@ -265,51 +200,16 @@ describe("workspace-sync session hooks", () => {
       workspaceSyncPlugin.register(api as any);
       await hooks.session_start!({}, { agentId: "main", sessionId: "s1" });
 
-      expect(api.logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("first sync requires manual --resync"),
-      );
+      expect(syncManager.triggerImmediateSync).toHaveBeenCalled();
     });
 
-    it("logs error on sync failure", async () => {
-      vi.mocked(rclone.isRcloneInstalled).mockResolvedValue(true);
-      vi.mocked(rclone.isRcloneConfigured).mockReturnValue(true);
-      vi.mocked(rclone.resolveSyncConfig).mockReturnValue({
-        provider: "dropbox",
-        remoteName: "cloud",
-        remotePath: "openclaw-share",
-        localPath: "/workspace/shared",
-        configPath: "/home/.config/rclone/rclone.conf",
-        conflictResolve: "newer",
-        exclude: [],
-        copySymlinks: false,
-        interval: 0,
-        onSessionStart: true,
-        onSessionEnd: false,
-      });
-      vi.mocked(rclone.runBisync).mockResolvedValue({
-        ok: false,
-        error: "connection timeout",
-      });
+    it("catches and logs errors from triggerImmediateSync", async () => {
+      vi.mocked(syncManager.isSyncing).mockReturnValue(false);
+      vi.mocked(syncManager.triggerImmediateSync).mockRejectedValue(new Error("unexpected boom"));
 
       const { api, hooks } = createMockApi({
         provider: "dropbox",
-        remotePath: "openclaw-share",
-        onSessionStart: true,
-      });
-
-      workspaceSyncPlugin.register(api as any);
-      await hooks.session_start!({}, { agentId: "main", sessionId: "s1" });
-
-      expect(api.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("sync failed: connection timeout"),
-      );
-    });
-
-    it("catches and logs unexpected errors", async () => {
-      vi.mocked(rclone.isRcloneInstalled).mockRejectedValue(new Error("unexpected boom"));
-
-      const { api, hooks } = createMockApi({
-        provider: "dropbox",
+        mode: "mailbox",
         remotePath: "openclaw-share",
         onSessionStart: true,
       });
@@ -324,26 +224,12 @@ describe("workspace-sync session hooks", () => {
   });
 
   describe("session_end handler", () => {
-    it("runs bisync on session end", async () => {
-      vi.mocked(rclone.isRcloneInstalled).mockResolvedValue(true);
-      vi.mocked(rclone.isRcloneConfigured).mockReturnValue(true);
-      vi.mocked(rclone.resolveSyncConfig).mockReturnValue({
-        provider: "dropbox",
-        remoteName: "cloud",
-        remotePath: "openclaw-share",
-        localPath: "/workspace/shared",
-        configPath: "/home/.config/rclone/rclone.conf",
-        conflictResolve: "newer",
-        exclude: [],
-        copySymlinks: false,
-        interval: 0,
-        onSessionStart: false,
-        onSessionEnd: true,
-      });
-      vi.mocked(rclone.runBisync).mockResolvedValue({ ok: true, filesTransferred: 3 });
+    it("skips when sync is already in progress", async () => {
+      vi.mocked(syncManager.isSyncing).mockReturnValue(true);
 
       const { api, hooks } = createMockApi({
         provider: "dropbox",
+        mode: "mailbox",
         remotePath: "openclaw-share",
         onSessionEnd: true,
       });
@@ -351,31 +237,19 @@ describe("workspace-sync session hooks", () => {
       workspaceSyncPlugin.register(api as any);
       await hooks.session_end!({}, { agentId: "main", sessionId: "s1" });
 
-      expect(rclone.runBisync).toHaveBeenCalled();
       expect(api.logger.info).toHaveBeenCalledWith(
-        expect.stringContaining("session end sync completed"),
+        "[workspace-sync] sync already in progress, skipping session end trigger",
       );
+      expect(syncManager.triggerImmediateSync).not.toHaveBeenCalled();
     });
 
-    it("skips silently when rclone not configured", async () => {
-      vi.mocked(rclone.isRcloneInstalled).mockResolvedValue(true);
-      vi.mocked(rclone.isRcloneConfigured).mockReturnValue(false);
-      vi.mocked(rclone.resolveSyncConfig).mockReturnValue({
-        provider: "dropbox",
-        remoteName: "cloud",
-        remotePath: "openclaw-share",
-        localPath: "/workspace/shared",
-        configPath: "/home/.config/rclone/rclone.conf",
-        conflictResolve: "newer",
-        exclude: [],
-        copySymlinks: false,
-        interval: 0,
-        onSessionStart: false,
-        onSessionEnd: true,
-      });
+    it("calls triggerImmediateSync on session end", async () => {
+      vi.mocked(syncManager.isSyncing).mockReturnValue(false);
+      vi.mocked(syncManager.triggerImmediateSync).mockResolvedValue();
 
       const { api, hooks } = createMockApi({
         provider: "dropbox",
+        mode: "mailbox",
         remotePath: "openclaw-share",
         onSessionEnd: true,
       });
@@ -383,7 +257,21 @@ describe("workspace-sync session hooks", () => {
       workspaceSyncPlugin.register(api as any);
       await hooks.session_end!({}, { agentId: "main", sessionId: "s1" });
 
-      expect(rclone.runBisync).not.toHaveBeenCalled();
+      expect(syncManager.triggerImmediateSync).toHaveBeenCalled();
+    });
+
+    it("skips silently when provider is off", async () => {
+      const { api, hooks } = createMockApi({
+        provider: "off",
+        mode: "mailbox",
+        remotePath: "openclaw-share",
+        onSessionEnd: true,
+      });
+
+      workspaceSyncPlugin.register(api as any);
+      await hooks.session_end!({}, { agentId: "main", sessionId: "s1" });
+
+      expect(syncManager.triggerImmediateSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/inbox-tool.test.ts
+++ b/tests/inbox-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { mkdirSync, writeFileSync, existsSync, readdirSync, rmSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createInboxTool } from "../src/inbox-tool.js";
@@ -73,6 +73,14 @@ describe("inbox-tool", () => {
       expect(data.workspaceDirectories).not.toContain("_outbox");
       expect(data.workspaceDirectories).not.toContain("_inbox");
     });
+
+    it("shows symlinks as symlinks (lstat, not stat)", async () => {
+      writeFileSync(join(wsDir, "outside.txt"), "outside");
+      symlinkSync(join(wsDir, "outside.txt"), join(inboxDir, "link.txt"));
+      const res = await tool.execute("test", { action: "list" });
+      const data = getResult(res);
+      expect(data.inbox[0]).toContain("symlink");
+    });
   });
 
   describe("peek", () => {
@@ -106,6 +114,26 @@ describe("inbox-tool", () => {
       const res = await tool.execute("test", { action: "peek" });
       const data = getResult(res);
       expect(data.error).toContain("required");
+    });
+
+    it("rejects path traversal in peek", async () => {
+      const res = await tool.execute("test", { action: "peek", target: "../../etc/passwd" });
+      const data = getResult(res);
+      expect(data.error).toContain("simple filename");
+    });
+
+    it("rejects paths with separators in peek", async () => {
+      const res = await tool.execute("test", { action: "peek", target: "sub/file.txt" });
+      const data = getResult(res);
+      expect(data.error).toContain("simple filename");
+    });
+
+    it("reports symlinks without following them", async () => {
+      writeFileSync(join(wsDir, "secret.txt"), "secret");
+      symlinkSync(join(wsDir, "secret.txt"), join(inboxDir, "link.txt"));
+      const res = await tool.execute("test", { action: "peek", target: "link.txt" });
+      const data = getResult(res);
+      expect(data.type).toBe("symlink");
     });
   });
 
@@ -146,7 +174,7 @@ describe("inbox-tool", () => {
       expect(data.error).toContain("relative path");
     });
 
-    it("rejects path traversal", async () => {
+    it("rejects path traversal in target", async () => {
       writeFileSync(join(inboxDir, "f.txt"), "data");
       const res = await tool.execute("test", { action: "move", target: "../../etc" });
       const data = getResult(res);
@@ -167,6 +195,56 @@ describe("inbox-tool", () => {
       expect(data.moved).toHaveLength(1);
       expect(existsSync(join(wsDir, "dest", "subdir", "inner.txt"))).toBe(true);
       expect(existsSync(join(inboxDir, "subdir"))).toBe(false);
+    });
+
+    it("rejects files[] entries with path traversal", async () => {
+      writeFileSync(join(inboxDir, "good.txt"), "data");
+      const res = await tool.execute("test", {
+        action: "move",
+        target: "dest",
+        files: ["good.txt", "../escape.txt"],
+      });
+      const data = getResult(res);
+      expect(data.moved).toHaveLength(1);
+      expect(data.errors).toHaveLength(1);
+      expect(data.errors[0]).toContain("simple filename");
+    });
+
+    it("rejects files[] entries with path separators", async () => {
+      writeFileSync(join(inboxDir, "good.txt"), "data");
+      const res = await tool.execute("test", {
+        action: "move",
+        target: "dest",
+        files: ["sub/file.txt"],
+      });
+      const data = getResult(res);
+      expect(data.errors).toHaveLength(1);
+      expect(data.errors[0]).toContain("simple filename");
+    });
+
+    it("skips symlinks in inbox during move", async () => {
+      writeFileSync(join(wsDir, "real.txt"), "real");
+      symlinkSync(join(wsDir, "real.txt"), join(inboxDir, "link.txt"));
+      writeFileSync(join(inboxDir, "safe.txt"), "safe");
+      const res = await tool.execute("test", { action: "move", target: "dest" });
+      const data = getResult(res);
+      expect(data.moved).toHaveLength(1);
+      expect(data.moved[0]).toContain("safe.txt");
+      expect(data.errors).toHaveLength(1);
+      expect(data.errors[0]).toContain("symlink");
+    });
+  });
+
+  describe("custom inbox path", () => {
+    it("uses provided inboxPath instead of wsDir/_inbox", async () => {
+      const customInbox = join(wsDir, "subfolder", "_inbox");
+      mkdirSync(customInbox, { recursive: true });
+      writeFileSync(join(customInbox, "test.txt"), "data");
+      const customTool = createInboxTool(wsDir, customInbox);
+      const res = await customTool.execute("test", { action: "list" });
+      const data = getResult(res);
+      expect(data.inbox).toHaveLength(1);
+      expect(data.inbox[0]).toContain("test.txt");
     });
   });
 });

--- a/tests/inbox-tool.test.ts
+++ b/tests/inbox-tool.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createInboxTool } from "../src/inbox-tool.js";
+
+describe("inbox-tool", () => {
+  let wsDir: string;
+  let inboxDir: string;
+  let tool: ReturnType<typeof createInboxTool>;
+
+  beforeEach(() => {
+    wsDir = join(tmpdir(), `inbox-tool-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(wsDir, { recursive: true });
+    inboxDir = join(wsDir, "_inbox");
+    mkdirSync(inboxDir, { recursive: true });
+    tool = createInboxTool(wsDir);
+  });
+
+  afterEach(() => {
+    rmSync(wsDir, { recursive: true, force: true });
+  });
+
+  function getResult(res: { content: { text: string }[] }) {
+    return JSON.parse(res.content[0].text);
+  }
+
+  describe("list", () => {
+    it("shows empty inbox", async () => {
+      rmSync(inboxDir, { recursive: true, force: true });
+      mkdirSync(inboxDir, { recursive: true });
+      const res = await tool.execute("test", { action: "list" });
+      const data = getResult(res);
+      expect(data.inbox).toEqual(["(empty)"]);
+    });
+
+    it("lists inbox files with sizes", async () => {
+      writeFileSync(join(inboxDir, "hello.txt"), "hello world");
+      const res = await tool.execute("test", { action: "list" });
+      const data = getResult(res);
+      expect(data.inbox).toHaveLength(1);
+      expect(data.inbox[0]).toContain("hello.txt");
+    });
+
+    it("lists workspace directories", async () => {
+      mkdirSync(join(wsDir, "CODE"), { recursive: true });
+      mkdirSync(join(wsDir, "docs"), { recursive: true });
+      const res = await tool.execute("test", { action: "list" });
+      const data = getResult(res);
+      expect(data.workspaceDirectories).toContain("CODE");
+      expect(data.workspaceDirectories).toContain("docs");
+    });
+
+    it("lists nested directories up to depth 3", async () => {
+      mkdirSync(join(wsDir, "CODE", "project", "src"), { recursive: true });
+      const res = await tool.execute("test", { action: "list" });
+      const data = getResult(res);
+      expect(data.workspaceDirectories).toContain("CODE");
+      expect(data.workspaceDirectories).toContain("CODE/project");
+      expect(data.workspaceDirectories).toContain("CODE/project/src");
+    });
+
+    it("excludes hidden dirs, node_modules, _inbox, _outbox", async () => {
+      mkdirSync(join(wsDir, ".git"), { recursive: true });
+      mkdirSync(join(wsDir, "node_modules"), { recursive: true });
+      mkdirSync(join(wsDir, "_outbox"), { recursive: true });
+      mkdirSync(join(wsDir, "real"), { recursive: true });
+      const res = await tool.execute("test", { action: "list" });
+      const data = getResult(res);
+      expect(data.workspaceDirectories).toContain("real");
+      expect(data.workspaceDirectories).not.toContain(".git");
+      expect(data.workspaceDirectories).not.toContain("node_modules");
+      expect(data.workspaceDirectories).not.toContain("_outbox");
+      expect(data.workspaceDirectories).not.toContain("_inbox");
+    });
+  });
+
+  describe("peek", () => {
+    it("returns file info", async () => {
+      writeFileSync(join(inboxDir, "doc.pdf"), Buffer.alloc(2048));
+      const res = await tool.execute("test", { action: "peek", target: "doc.pdf" });
+      const data = getResult(res);
+      expect(data.type).toBe("file");
+      expect(data.name).toBe("doc.pdf");
+      expect(data.size).toBe("2.0KB");
+    });
+
+    it("returns directory entries", async () => {
+      mkdirSync(join(inboxDir, "folder"));
+      writeFileSync(join(inboxDir, "folder", "a.txt"), "a");
+      writeFileSync(join(inboxDir, "folder", "b.txt"), "b");
+      const res = await tool.execute("test", { action: "peek", target: "folder" });
+      const data = getResult(res);
+      expect(data.type).toBe("directory");
+      expect(data.entries).toContain("a.txt");
+      expect(data.entries).toContain("b.txt");
+    });
+
+    it("returns error for missing file", async () => {
+      const res = await tool.execute("test", { action: "peek", target: "nope.txt" });
+      const data = getResult(res);
+      expect(data.error).toContain("not found");
+    });
+
+    it("requires target", async () => {
+      const res = await tool.execute("test", { action: "peek" });
+      const data = getResult(res);
+      expect(data.error).toContain("required");
+    });
+  });
+
+  describe("move", () => {
+    it("moves all inbox files to target dir", async () => {
+      writeFileSync(join(inboxDir, "a.txt"), "aaa");
+      writeFileSync(join(inboxDir, "b.txt"), "bbb");
+      const res = await tool.execute("test", { action: "move", target: "CODE/project" });
+      const data = getResult(res);
+      expect(data.moved).toHaveLength(2);
+      expect(existsSync(join(wsDir, "CODE", "project", "a.txt"))).toBe(true);
+      expect(existsSync(join(wsDir, "CODE", "project", "b.txt"))).toBe(true);
+      expect(data.remaining).toBe(0);
+    });
+
+    it("moves specific files only", async () => {
+      writeFileSync(join(inboxDir, "a.txt"), "aaa");
+      writeFileSync(join(inboxDir, "b.txt"), "bbb");
+      const res = await tool.execute("test", { action: "move", target: "docs", files: ["a.txt"] });
+      const data = getResult(res);
+      expect(data.moved).toHaveLength(1);
+      expect(existsSync(join(wsDir, "docs", "a.txt"))).toBe(true);
+      expect(existsSync(join(inboxDir, "b.txt"))).toBe(true);
+      expect(data.remaining).toBe(1);
+    });
+
+    it("creates target directory if missing", async () => {
+      writeFileSync(join(inboxDir, "f.txt"), "data");
+      expect(existsSync(join(wsDir, "new-dir"))).toBe(false);
+      await tool.execute("test", { action: "move", target: "new-dir" });
+      expect(existsSync(join(wsDir, "new-dir", "f.txt"))).toBe(true);
+    });
+
+    it("rejects absolute target paths", async () => {
+      writeFileSync(join(inboxDir, "f.txt"), "data");
+      const res = await tool.execute("test", { action: "move", target: "/tmp/evil" });
+      const data = getResult(res);
+      expect(data.error).toContain("relative path");
+    });
+
+    it("rejects path traversal", async () => {
+      writeFileSync(join(inboxDir, "f.txt"), "data");
+      const res = await tool.execute("test", { action: "move", target: "../../etc" });
+      const data = getResult(res);
+      expect(data.error).toContain("within the workspace");
+    });
+
+    it("requires target", async () => {
+      const res = await tool.execute("test", { action: "move" });
+      const data = getResult(res);
+      expect(data.error).toContain("required");
+    });
+
+    it("handles directory items in inbox", async () => {
+      mkdirSync(join(inboxDir, "subdir"));
+      writeFileSync(join(inboxDir, "subdir", "inner.txt"), "inner");
+      const res = await tool.execute("test", { action: "move", target: "dest" });
+      const data = getResult(res);
+      expect(data.moved).toHaveLength(1);
+      expect(existsSync(join(wsDir, "dest", "subdir", "inner.txt"))).toBe(true);
+      expect(existsSync(join(inboxDir, "subdir"))).toBe(false);
+    });
+  });
+});

--- a/tests/rclone.test.ts
+++ b/tests/rclone.test.ts
@@ -21,7 +21,7 @@ describe("rclone helpers", () => {
 
       expect(resolved.provider).toBe("dropbox");
       expect(resolved.remotePath).toBe("test-folder");
-      expect(resolved.localPath).toBe(path.join(workspaceDir, "shared"));
+      expect(resolved.localPath).toBe(workspaceDir);
       expect(resolved.remoteName).toBe("cloud");
       expect(resolved.conflictResolve).toBe("newer");
       expect(resolved.interval).toBe(0);
@@ -79,8 +79,7 @@ describe("rclone helpers", () => {
       const config = { provider: "dropbox" as const, remotePath: "test" };
       const resolved = resolveSyncConfig(config, "/workspace", "/state");
 
-      expect(resolved.exclude).toContain(".git/**");
-      expect(resolved.exclude).toContain("node_modules/**");
+      expect(resolved.exclude).toContain("**/.DS_Store");
     });
 
     it("respects custom excludes", () => {

--- a/tests/sync-manager.test.ts
+++ b/tests/sync-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { startSyncManager, stopSyncManager, getSyncManagerStatus } from "../src/sync-manager.js";
+import { startSyncManager, stopSyncManager, getSyncManagerStatus, isSyncing } from "../src/sync-manager.js";
 
 const mockLogger = {
   debug: vi.fn(),
@@ -29,6 +29,12 @@ describe("sync-manager", () => {
     });
   });
 
+  describe("isSyncing", () => {
+    it("returns false when not syncing", () => {
+      expect(isSyncing()).toBe(false);
+    });
+  });
+
   describe("startSyncManager", () => {
     it("logs and returns when provider is off", () => {
       startSyncManager({ provider: "off" }, "/workspace", "/state", mockLogger);
@@ -48,9 +54,23 @@ describe("sync-manager", () => {
       expect(getSyncManagerStatus().running).toBe(false);
     });
 
+    it("errors when mode is not set", () => {
+      startSyncManager(
+        { provider: "dropbox", interval: 300 },
+        "/workspace",
+        "/state",
+        mockLogger,
+      );
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('"mode" is now required'),
+      );
+      expect(getSyncManagerStatus().running).toBe(false);
+    });
+
     it("logs disabled when interval is 0", () => {
       startSyncManager(
-        { provider: "dropbox", interval: 0 },
+        { provider: "dropbox", mode: "mailbox", interval: 0 },
         "/workspace",
         "/state",
         mockLogger,
@@ -64,7 +84,7 @@ describe("sync-manager", () => {
 
     it("enforces minimum 60s interval", () => {
       startSyncManager(
-        { provider: "dropbox", interval: 10 },
+        { provider: "dropbox", mode: "mailbox", interval: 10 },
         "/workspace",
         "/state",
         mockLogger,
@@ -78,14 +98,14 @@ describe("sync-manager", () => {
 
     it("starts with valid interval", () => {
       startSyncManager(
-        { provider: "dropbox", interval: 300 },
+        { provider: "dropbox", mode: "mailbox", interval: 300 },
         "/workspace",
         "/state",
         mockLogger,
       );
 
       expect(mockLogger.info).toHaveBeenCalledWith(
-        "[workspace-sync] Starting periodic sync every 300s (pure file sync, zero LLM cost)",
+        "[workspace-sync] Starting periodic sync every 300s in mailbox mode (pure file sync, zero LLM cost)",
       );
       expect(getSyncManagerStatus().running).toBe(true);
     });
@@ -94,7 +114,7 @@ describe("sync-manager", () => {
   describe("stopSyncManager", () => {
     it("stops a running manager", () => {
       startSyncManager(
-        { provider: "dropbox", interval: 300 },
+        { provider: "dropbox", mode: "mailbox", interval: 300 },
         "/workspace",
         "/state",
         mockLogger,


### PR DESCRIPTION
## Summary

### Sync overlap prevention (original)
- Export `isSyncing()` from sync manager so session hooks can check state
- Refactor `session_start` / `session_end` hooks to delegate to `triggerImmediateSync()` instead of spawning independent rclone processes
- Prevents 3 concurrent syncs (background + session start + session end) that caused Dropbox rate limiting and timeouts

### Inbox notification & agent tool (new)
- **Enhanced notification**: when `notifyOnInbox: true`, the system event now includes a bullet-point file listing (up to 10) and top-level workspace directories, so the agent can suggest where to move files
- **`workspace_inbox` agent tool**: registered automatically in mailbox mode with 3 actions:
  - `list` — show inbox files (with sizes) + workspace directories (up to 3 levels deep)
  - `peek` — inspect a specific inbox file/directory (metadata)
  - `move` — move inbox files to a target workspace directory; creates target if needed; validates paths (rejects absolute paths and traversal)
- Flow: files arrive in cloud `_outbox` → mailbox drain pulls to local `_inbox` → agent notifies on Telegram → user says where to move → agent calls tool

## Test plan
- [x] All 77 tests pass (16 new for inbox tool)
- [ ] Deploy to habibi-bot with `notifyOnInbox: true` and verify notification on Telegram
- [ ] Drop a file in Dropbox `_outbox`, confirm agent notification + interactive move